### PR TITLE
Fixes broken cleanup

### DIFF
--- a/nac.CurlThin/SafeHandles/SafeEasyHandle.cs
+++ b/nac.CurlThin/SafeHandles/SafeEasyHandle.cs
@@ -5,7 +5,7 @@ namespace nac.CurlThin.SafeHandles
 {
     public sealed class SafeEasyHandle : SafeHandle
     {
-        private SafeEasyHandle() : base(IntPtr.Zero, false)
+        private SafeEasyHandle() : base(IntPtr.Zero, true)
         {
         }
 

--- a/nac.CurlThin/SafeHandles/SafeMultiHandle.cs
+++ b/nac.CurlThin/SafeHandles/SafeMultiHandle.cs
@@ -5,7 +5,7 @@ namespace nac.CurlThin.SafeHandles
 {
     public sealed class SafeMultiHandle : SafeHandle
     {
-        private SafeMultiHandle() : base(IntPtr.Zero, false)
+        private SafeMultiHandle() : base(IntPtr.Zero, true)
         {
         }
 

--- a/nac.CurlThin/SafeHandles/SafeSlistHandle.cs
+++ b/nac.CurlThin/SafeHandles/SafeSlistHandle.cs
@@ -5,7 +5,7 @@ namespace nac.CurlThin.SafeHandles
 {
     public sealed class SafeSlistHandle : SafeHandle
     {
-        private SafeSlistHandle() : base(IntPtr.Zero, false)
+        private SafeSlistHandle() : base(IntPtr.Zero, true)
         {
         }
 


### PR DESCRIPTION
I noticed that my cookie jar was not saving, leading me to discover this: https://github.com/stil/CurlThin/issues/15

Apparently, the SafeHandles don't actually fire their Cleanup method when being disposed of. I changed it and recompiled and my cookie jar wrote when disposed, so it seems to be fixed.