### PR TITLE
Fixes GC error when cleanup

### DIFF
--- a/Tests/lib/libCurlTester.cs
+++ b/Tests/lib/libCurlTester.cs
@@ -113,8 +113,7 @@ public class libCurlTester: IDisposable
 
         if (headers != null)
         {
-            // Cleanup HTTP header list after request has complete.
-            CurlNative.Slist.FreeAll(headers);
+            headers.Dispose();
         }
     }
 }

--- a/nac.CurlThin/CurlNative.cs
+++ b/nac.CurlThin/CurlNative.cs
@@ -136,7 +136,7 @@ namespace nac.CurlThin
             public static extern SafeSlistHandle Append(SafeSlistHandle slist, string data);
             
             [DllImport(LIBCURL, EntryPoint = "curl_slist_free_all")]
-            public static extern void FreeAll(SafeSlistHandle pList);
+            public static extern void FreeAll(IntPtr handle);
         }
     }
 }

--- a/nac.CurlThin/SafeHandles/SafeSlistHandle.cs
+++ b/nac.CurlThin/SafeHandles/SafeSlistHandle.cs
@@ -15,7 +15,7 @@ namespace nac.CurlThin.SafeHandles
 
         protected override bool ReleaseHandle()
         {
-            CurlNative.Slist.FreeAll(this);
+            CurlNative.Slist.FreeAll(handle);
             return true;
         }
     }


### PR DESCRIPTION
SafeSlistHandle.ReleaseHandle()
CurlNative.Slist.FreeAll(this)<--- this trigger DangerousAddRef
then 
![image](https://github.com/NathanielACollier/dotnetLib_nac.CurlThin/assets/38383994/ea7b0792-401b-4eea-b805-9f147d945a5a)

but it called InternalRelease already
![image](https://github.com/NathanielACollier/dotnetLib_nac.CurlThin/assets/38383994/a045550e-0441-4612-abd6-c2e4c206f5f4)
